### PR TITLE
Create template_quickstart.md

### DIFF
--- a/doc_templates/template_quickstart.md
+++ b/doc_templates/template_quickstart.md
@@ -1,0 +1,33 @@
+---
+title: [Title of the quickstart guide, recommended format: VERBing the/a(n)/Your NOUN, title-case]
+permalink: [link, e.g. /getting-started/quickstart-guide]
+---
+This quickstart guide will help you [describe what the user will achieve by the end of the guide]. [Explain goal, domain-related background information, any information that helps understand the purpose or terminology of the quickstart guide.]
+
+[Purpose of quickstart guide/title] is a [number of large steps, e.g. two]-step process:
+* [step 1 short description, format VERB the/a(n)/your NOUN]
+* [step 2 short description, format VERB the/a(n)/your NOUN]
+
+## Step 1: [Step 1 short description]
+
+[Detailed description of what the user has to do in this step, including all necessary background information and domain-knowledge. Can contain descriptions, bulleted and numbered lists, screenshots, links.]
+
+## Step 2: [Step 2 short description]
+
+[Detailed description of what the user has to do in this step, including all necessary background information and domain-knowledge. Can contain descriptions, bulleted and numbered lists, screenshots, links.]
+
+## Step n: [Step n short description]
+
+[Detailed description of what the user has to do in this step, including all necessary background information and domain-knowledge. Can contain descriptions, bulleted and numbered lists, screenshots, links.]
+
+## Next steps
+Congratulations! You have [what the user has achieved]. You may now want to check out these resources:  
+
+* [[Link to related topic]]() 
+* [[Link to related topic]]() 
+* [[Link to related topic]]() 
+* [[Link to related topic]]() 
+* [[Link to related topic - max 5 links]]() 
+
+## Questions? 
+We are always happy to help with any questions you may have. Consult our [documentation](), [contact support](), or [connect with our sales team](). 


### PR DESCRIPTION
Created the documentation template for the quickstart guide content type, part of the documentation templates package. 
Should be updated whenever we change the format of quickstart guides to keep all newly created guides consistent.