### PR TITLE
Update platformos-components.md

### DIFF
--- a/_PlatformOS/how-platformos-works/platformos-components.md
+++ b/_PlatformOS/how-platformos-works/platformos-components.md
@@ -42,7 +42,5 @@ In order to correctly communicate with the Platform OS engine and API, your code
 | `transactable_types`     | Directory for files that define Transactable Types.                                                                                                                                                                                  | Transactables <br>Transactable Types |
 | `translations`           | Directory for yml files of Translations for multilingual sites, also used to define date format, or flash messages.                                                                                                                  | Translations                     |
 
-[TO BE ADDED: diagram2: marketplace_builder required file structure]
-
 
 


### PR DESCRIPTION
Removed placeholder for file structure diagram as the file structure is expected to change more often than we want to create images. 