### PR TITLE
z-index bug on bootstrap alerts

### DIFF
--- a/src/scss/modules/_masthead.scss
+++ b/src/scss/modules/_masthead.scss
@@ -5,6 +5,7 @@
   right: 0;
   background: #333;
   padding: 0;
+  z-index: 1;
 }
 
 body {


### PR DESCRIPTION
The header has no z-index value so the bootstrap alerts overlap the header when scrolling.  Simple fix to z-index the header to 1 to "always" be ontop


Before Fix:
<img width="512" alt="screen shot 2018-03-30 at 13 54 42" src="https://user-images.githubusercontent.com/15265711/38138299-193f7a42-3422-11e8-8f68-7ac375d6c5c4.png">

After Fix:
<img width="1381" alt="screen shot 2018-03-30 at 13 56 38" src="https://user-images.githubusercontent.com/15265711/38138320-31b927c6-3422-11e8-9bf3-05a1da817b0b.png">

